### PR TITLE
Correctly handle all filenames

### DIFF
--- a/src/inotify_folder_watcher.erl
+++ b/src/inotify_folder_watcher.erl
@@ -21,7 +21,7 @@ init({Folders, Parent}) ->
 
 recurse_folders(Fd, []) -> done;
 recurse_folders(Fd, [Folder|T]) ->
-    AbsFolder = filename:absname(unicode:characters_to_binary(Folder)),
+    AbsFolder = filename:absname(Folder),
     IsDir = filelib:is_dir(AbsFolder),
 
     %io:format("abstocheck ~p \n", [AbsFolder]),
@@ -39,7 +39,7 @@ recurse_folders(Fd, [Folder|T]) ->
 
         {ok, Files} ->
             self() ! {watch_file, AbsFolder},
-            Files2 = [filename:join(AbsFolder, unicode:characters_to_binary(X)) || X <- Files],
+            Files2 = [filename:join(AbsFolder, X) || X <- Files],
             recurse_folders(Fd, T++Files2)
     end
     .


### PR DESCRIPTION
The original API neurotically converts everything from UTF-8; as documented in the refs, this is not required: Erlang filenames can be either character strings or binaries, and this works transparently:
`:filename.absname(~c".")` yields a ~c"..." of the working directory, but
`:filename.absname(".")` yields a binary of the working directory;
`:filename.join(~c".", ~c"a")` yields `~c"./a"` but all other combinations of `[~c".", "."]` x `[~c"a", "a"]` yield "./a"

`:file.list_dir()` returns a `[~c"..."]` and globally logs
```
[warning] Non-unicode filename <<255, 43, ...>> ignored
```
when it sees a filename that can't become a character sequence; `:file.list_dir_all()` returns a `[~c"..." | binary]`, each of which we can join directly

(Naturally, when a filename is a binary that can't be decoded from UTF-8,  feeding it to `:unicode.characters_to_binary()` errors, because `:unicode.characters_to_binary(binary)` tries to decode `binary` instead of passing it through.)

This allows us to process all valid filenames, both as-given and as listed in a directory; to test, try watching `mkdir $'\377'; echo contents > $'\377/\377'`

Ref: https://www.erlang.org/doc/apps/stdlib/unicode_usage#notes-about-raw-filenames
Ref: https://www.erlang.org/doc/apps/kernel/file.html
Ref: https://www.erlang.org/doc/apps/kernel/file.html#list_dir/1
Sponsored-by: https://beaverlabs.net